### PR TITLE
Feat: Add support for Creality Sonic Pad

### DIFF
--- a/scripts/install-mobileraker-companion.sh
+++ b/scripts/install-mobileraker-companion.sh
@@ -1,13 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script installs the Mobileraker-Companion on a Raspi
 
 PYTHONDIR="${MOBILERAKER_VENV:-${HOME}/mobileraker-env}"
 REBUILD_ENV="${MOBILERAKER_REBUILD_ENV:-n}"
 FORCE_DEFAULTS="${MOBILERAKER_FORCE_DEFAULTS:-n}"
 LOG_PATH="${MOBILERAKER_LOG_PATH:-/tmp/mobileraker.log}"
-
-SYSTEMDDIR="/etc/systemd/system"
-
+SYSTEMDDIR="${SYSTEMDDIR:-/etc/systemd/system}"
 MOONRAKER_ASVC=~/printer_data/moonraker.asvc
 
 # If we're running as root we don't need sudo.
@@ -17,31 +15,29 @@ else
     SUDO="sudo"
 fi
 
-create_virtualenv()
-{
+create_virtualenv() {
     report_status "Installing python virtual environment..."
 
     # If venv exists and user prompts a rebuild, then do so
-    if [ -d ${PYTHONDIR} ] && [ $REBUILD_ENV = "y" ]; then
+    if [ -d "${PYTHONDIR}" ] && [ "$REBUILD_ENV" = "y" ]; then
         report_status "Removing old virtualenv"
-        rm -rf ${PYTHONDIR}
+        rm -rf "${PYTHONDIR}"
     fi
 
-    if [ ! -d ${PYTHONDIR} ]; then
-        virtualenv -p /usr/bin/python3 ${PYTHONDIR}
+    if [ ! -d "${PYTHONDIR}" ]; then
+        virtualenv -p /usr/bin/python3 "${PYTHONDIR}"
     fi
 
     # Install/update dependencies
-    ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/mobileraker-requirements.txt
+    "${PYTHONDIR}"/bin/pip install -r "${SRCDIR}/scripts/mobileraker-requirements.txt"
 }
 
-install_script()
-{
-# Create systemd service file
+install_script() {
+    # Create systemd service file
     SERVICE_FILE="${SYSTEMDDIR}/mobileraker.service"
-    [ -f $SERVICE_FILE ] && [ $FORCE_DEFAULTS = "n" ] && return
+    [ -f "$SERVICE_FILE" ] && [ "$FORCE_DEFAULTS" = "n" ] && return
     report_status "Installing system start script..."
-    $SUDO /bin/sh -c "cat > ${SERVICE_FILE}" << EOF
+    "$SUDO" /bin/sh -c "cat > ${SERVICE_FILE}" <<EOF
 #Systemd service file for mobileraker
 [Unit]
 Description=Companion app to enable push notifications on mobileraker
@@ -58,65 +54,105 @@ ExecStart=${LAUNCH_CMD} -l ${LOG_PATH}
 Restart=always
 RestartSec=10
 EOF
-# Use systemctl to enable the klipper systemd service script
-    $SUDO systemctl enable mobileraker.service
-    $SUDO systemctl daemon-reload
+    # Use systemctl to enable the klipper systemd service script
+    "$SUDO" systemctl enable mobileraker.service
+    "$SUDO" systemctl daemon-reload
 }
 
+# Add support for the Creality Sonic Pad which does not use systemd.
+install_script_creality() {
+    # Create init script
+    [ -f "$SERVICE_FILE" ] && [ "$FORCE_DEFAULTS" = "n" ] && return
+    report_status "Installing system start script..."
 
-start_software()
-{
+    # If the service file already exists, rename it to .bak
+    [ -f "$SERVICE_FILE" ] && mv "$SERVICE_FILE" "${SERVICE_FILE}.bak"
+    INIT_SCRIPT='#!/bin/sh /etc/rc.common
+# Companion app to enable push notifications on mobileraker
+START=55
+STOP=1
+DEPEND=fstab
+start_service() {
+    procd_open_instance
+    procd_set_param env HOME=/root
+    procd_set_param command ${LAUNCH_CMD} -l ${LOG_PATH}
+    procd_close_instance
+}'
+    echo "$INIT_SCRIPT" >"$SERVICE_FILE"
+    chmod +x "$SERVICE_FILE"
+}
+
+start_software() {
     report_status "Launching mobileraker Companion..."
-    $SUDO systemctl restart mobileraker
+    "$SUDO" systemctl restart mobileraker
 }
 
 # Helper functions
-report_status()
-{
+report_status() {
     echo -e "\n\n###### $1"
 }
 
-verify_ready()
-{
+verify_ready() {
     if [ "$EUID" -eq 0 ]; then
         echo "This script must not run as root"
-        exit -1
+        exit 1
     fi
 }
 
-
-
-add_to_asvc()
-{
+add_to_asvc() {
     report_status "Trying to add mobileraker to service list"
-    if [ -f $MOONRAKER_ASVC ]; then
+    if [ -f "$MOONRAKER_ASVC" ]; then
         echo "moonraker.asvc was found"
-        if ! grep -q mobileraker $MOONRAKER_ASVC; then
+        if ! grep -q mobileraker "$MOONRAKER_ASVC"; then
             echo "moonraker.asvc does not contain 'mobileraker'! Adding it..."
-            echo -e "\nmobileraker" >> $MOONRAKER_ASVC
+            echo -e "\nmobileraker" >>"$MOONRAKER_ASVC"
         fi
     fi
+}
+
+is_creality_device() {
+    if [ -d "/usr/share/creality-env/" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+setup_creality_device() {
+    MOONRAKER_ASVC="/mnt/UDISK/printer_config"
+    SYSTEMDDIR="/etc/init.d"
+    SERVICE_FILE="${SYSTEMDDIR}/mobileraker.service"
+    PYTHONDIR="/usr/share/moonraker-env"
+    python3 -m pip install --user virtualenv
+    create_virtualenv
+    install_script_creality
 }
 
 # Force script to exit if an error occurs
 set -e
 
 # Find SRCDIR from the pathname of this script
-SRCDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
+SRCDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 LAUNCH_CMD="${PYTHONDIR}/bin/python ${SRCDIR}/mobileraker.py"
 
 # Parse command line arguments
 while getopts "rfc:l:" arg; do
     case $arg in
-        r) REBUILD_ENV="y";;
-        f) FORCE_DEFAULTS="y";;
-        l) LOG_PATH=$OPTARG;;
+    r) REBUILD_ENV="y" ;;
+    f) FORCE_DEFAULTS="y" ;;
+    l) LOG_PATH=$OPTARG ;;
     esac
 done
 
 # Run installation steps defined above
-verify_ready
-create_virtualenv
-install_script
-add_to_asvc
-start_software
+if is_creality_device; then
+    setup_creality_device
+    add_to_asvc
+    /etc/init.d/mobileraker.service start
+else
+    verify_ready
+    create_virtualenv
+    install_script
+    add_to_asvc
+    start_software
+fi

--- a/scripts/install-mobileraker-companion.sh
+++ b/scripts/install-mobileraker-companion.sh
@@ -10,6 +10,13 @@ SYSTEMDDIR="/etc/systemd/system"
 
 MOONRAKER_ASVC=~/printer_data/moonraker.asvc
 
+# If we're running as root we don't need sudo.
+if [ "$EUID" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
 create_virtualenv()
 {
     report_status "Installing python virtual environment..."
@@ -34,7 +41,7 @@ install_script()
     SERVICE_FILE="${SYSTEMDDIR}/mobileraker.service"
     [ -f $SERVICE_FILE ] && [ $FORCE_DEFAULTS = "n" ] && return
     report_status "Installing system start script..."
-    sudo /bin/sh -c "cat > ${SERVICE_FILE}" << EOF
+    $SUDO /bin/sh -c "cat > ${SERVICE_FILE}" << EOF
 #Systemd service file for mobileraker
 [Unit]
 Description=Companion app to enable push notifications on mobileraker
@@ -52,15 +59,15 @@ Restart=always
 RestartSec=10
 EOF
 # Use systemctl to enable the klipper systemd service script
-    sudo systemctl enable mobileraker.service
-    sudo systemctl daemon-reload
+    $SUDO systemctl enable mobileraker.service
+    $SUDO systemctl daemon-reload
 }
 
 
 start_software()
 {
     report_status "Launching mobileraker Companion..."
-    sudo systemctl restart mobileraker
+    $SUDO systemctl restart mobileraker
 }
 
 # Helper functions

--- a/scripts/remove-mobileraker-companion.sh
+++ b/scripts/remove-mobileraker-companion.sh
@@ -4,6 +4,13 @@
 PYTHONDIR="${MOBILERAKER_VENV:-${HOME}/mobileraker-env}"
 SYSTEMDDIR="/etc/systemd/system"
 
+# If we're running as root we don't need sudo.
+if [ "$EUID" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
 remove_virtualenv()
 {
     report_status "Removing python virtual environment..."
@@ -21,12 +28,12 @@ remove_script()
     SERVICE_FILE="${SYSTEMDDIR}/mobileraker.service"
     [ ! -f $SERVICE_FILE ] && return
     report_status "Stopping the service ..."
-	sudo systemctl stop mobileraker.service
-	sudo systemctl disable mobileraker.service
-	report_status "Removing the service ..."
-	sudo rm $SERVICE_FILE 
+    $SUDO systemctl stop mobileraker.service
+    $SUDO systemctl disable mobileraker.service
+    report_status "Removing the service ..."
+    $SUDO rm $SERVICE_FILE
 
-    sudo systemctl daemon-reload
+    $SUDO systemctl daemon-reload
 }
 
 report_status()
@@ -45,8 +52,6 @@ verify_ready()
 
 # Force script to exit if an error occurs
 set -e
-
-
 
 # Run installation steps defined above
 verify_ready

--- a/scripts/remove-mobileraker-companion.sh
+++ b/scripts/remove-mobileraker-companion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script installs the Mobileraker-Companion on a Raspi
 
 PYTHONDIR="${MOBILERAKER_VENV:-${HOME}/mobileraker-env}"
@@ -16,24 +16,35 @@ remove_virtualenv()
     report_status "Removing python virtual environment..."
 
     # If venv exists and user prompts a rebuild, then do so
-    if [ -d ${PYTHONDIR} ]; then
+    if [ -d "${PYTHONDIR}" ]; then
         report_status "Removing virtualenv"
-        rm -rf ${PYTHONDIR}
+        rm -rf "${PYTHONDIR}"
     fi
 }
 
 remove_script()
 {
-# Create systemd service file
+# Remove systemd service file
     SERVICE_FILE="${SYSTEMDDIR}/mobileraker.service"
-    [ ! -f $SERVICE_FILE ] && return
+    [ ! -f "$SERVICE_FILE" ] && return
     report_status "Stopping the service ..."
-    $SUDO systemctl stop mobileraker.service
-    $SUDO systemctl disable mobileraker.service
+    "$SUDO" systemctl stop mobileraker.service
+    "$SUDO" systemctl disable mobileraker.service
     report_status "Removing the service ..."
-    $SUDO rm $SERVICE_FILE
+    "$SUDO" rm "$SERVICE_FILE"
 
-    $SUDO systemctl daemon-reload
+    "$SUDO" systemctl daemon-reload
+}
+
+remove_script_creality()
+{
+# Remove systemd service file
+    SERVICE_FILE="/etc/init.d/mobileraker.service"
+    [ ! -f "$SERVICE_FILE" ] && return
+    report_status "Stopping the service ..."
+    /etc/init.d/mobileraker.service stop
+    report_status "Removing the service ..."
+    rm "$SERVICE_FILE"
 }
 
 report_status()
@@ -45,15 +56,30 @@ verify_ready()
 {
     if [ "$EUID" -eq 0 ]; then
         echo "This script must not run as root"
-        exit -1
+        exit 1
     fi
 }
 
+is_creality_device()
+{
+    if [ -d "/usr/share/creality-env/" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 # Force script to exit if an error occurs
 set -e
 
-# Run installation steps defined above
-verify_ready
-remove_script
-remove_virtualenv
+
+# Run uninstallation steps defined above
+if is_creality_device; then
+    remove_script_creality
+    remove_virtualenv
+else
+    verify_ready
+    remove_script
+    remove_virtualenv
+fi
+


### PR DESCRIPTION
Add basic support for installing and uninstalling on Creality Sonic Pad devices.

- Only prefixes commands with `sudo` if not run as root.
- Support basic init scripts as found on the sonic pad.
- Correct some bash linting errors.

This resolves issues on some small embedded systems that only have a root account and/or don't have the sudo command available, and service management for the Creality Sonic Pad.