### PR TITLE
docker: add missing library to the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN python -m venv venv \
 FROM python:3-slim
 
 RUN apt update \
- && apt install -y git \
+ && apt install -y \
+      git \
+      libjpeg62-turbo \
  && apt clean
 
 WORKDIR /opt

--- a/scripts/install-mobileraker-companion.sh
+++ b/scripts/install-mobileraker-companion.sh
@@ -10,6 +10,12 @@ SYSTEMDDIR="/etc/systemd/system"
 
 MOONRAKER_ASVC=~/printer_data/moonraker.asvc
 
+install_dependencies()
+{
+    apt update
+    apt install -y git libjpeg62-turbo
+}
+
 create_virtualenv()
 {
     report_status "Installing python virtual environment..."
@@ -116,6 +122,7 @@ done
 
 # Run installation steps defined above
 verify_ready
+install_dependencies
 create_virtualenv
 install_script
 add_to_asvc


### PR DESCRIPTION
This adds the libjpeg62-turbo package to the docker Image. 

Related to https://github.com/Clon1998/mobileraker_companion/issues/30