### PR TITLE
script: use sudo when calling apt

### DIFF
--- a/scripts/install-mobileraker-companion.sh
+++ b/scripts/install-mobileraker-companion.sh
@@ -12,8 +12,8 @@ MOONRAKER_ASVC=~/printer_data/moonraker.asvc
 
 install_dependencies()
 {
-    apt update
-    apt install -y git libjpeg62-turbo
+    sudo apt update
+    sudo apt install -y git libjpeg62-turbo
 }
 
 create_virtualenv()


### PR DESCRIPTION
https://github.com/Clon1998/mobileraker_companion/pull/31 introduced a change to the install script to install dependencies via apt.  
If the script is run as an unprivileged user, dependencies can not be installed and the script fails.  
Sudo should therefore be used to call apt.

This fixes https://github.com/Clon1998/mobileraker_companion/issues/32

