### PR TITLE
Add requirements for pillow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ FROM python:3-slim
 RUN apt update \
  && apt install -y \
       git \
-      libjpeg62-turbo \
+      zlib1g \
+      libtiff5 libjpeg62-turbo libopenjp2-7 \
  && apt clean
 
 WORKDIR /opt

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cd mobileraker_companion
 Create a mobileraker.conf and run the following command
 ```
 docker run -d \
-    -n mobileraker_companion
+    --name mobileraker_companion
     -v /path/to/mobileraker.conf:/opt/printer_data/config/mobileraker.conf
     ghcr.io/Clon1998/mobileraker_companion:latest
 ```

--- a/README.md
+++ b/README.md
@@ -59,14 +59,14 @@ Create a mobileraker.conf and run the following command
 docker run -d \
     --name mobileraker_companion
     -v /path/to/mobileraker.conf:/opt/printer_data/config/mobileraker.conf
-    ghcr.io/Clon1998/mobileraker_companion:latest
+    ghcr.io/clon1998/mobileraker_companion:latest
 ```
 
 or via docker compose:
 ```yaml
 services:
   mobileraker_companion:
-    image: ghcr.io/Clon1998/mobileraker_companion:latest
+    image: ghcr.io/clon1998/mobileraker_companion:latest
     volumes:
     - /path/to/mobileraker.conf:/opt/printer_data/config/mobileraker.conf
 ```

--- a/scripts/install-mobileraker-companion.sh
+++ b/scripts/install-mobileraker-companion.sh
@@ -13,7 +13,10 @@ MOONRAKER_ASVC=~/printer_data/moonraker.asvc
 install_dependencies()
 {
     sudo apt update
-    sudo apt install -y git libjpeg62-turbo
+    sudo apt install -y \
+            git \
+            zlib1g \
+            libtiff5 libjpeg62-turbo libopenjp2-7
 }
 
 create_virtualenv()


### PR DESCRIPTION
Pillow requires external runtime libraries to be present when used on `armv7l` platform.  
This PR adds the required packages to the Dockerfile and install script. 

Fixes https://github.com/Clon1998/mobileraker_companion/issues/33