### PR TITLE
docker: explicitly use bookworm variant of python base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the venv
-FROM python:3 as build
+FROM python:3-bookworm as build
 
 WORKDIR /opt
 
@@ -8,13 +8,13 @@ RUN python -m venv venv \
  && venv/bin/pip install -r mobileraker-requirements.txt
 
 # Runtime Image
-FROM python:3-slim
+FROM python:3-slim-bookworm
 
 RUN apt update \
  && apt install -y \
       git \
-      zlib1g-dev \
-      libjpeg62-turbo-dev\
+      zlib1g \
+      libtiff6 libjpeg62-turbo libopenjp2-7 \
  && apt clean
 
 WORKDIR /opt


### PR DESCRIPTION
Recently, the python base images have switched from using debian bullseye to bookworm.  
This also meant that `libtiff5` is not available anymore and caused the build to fail.  

This PR explicitly uses the bookworm variants of the python base images and updates the required libraries for running the companion. 

This also fixes regressions introduced in 
* https://github.com/Clon1998/mobileraker_companion/commit/a9dbbce66808d142fe9ce80758a89ad4ff46a89b
* https://github.com/Clon1998/mobileraker_companion/commit/42210fa18e697b721ea55e4fc2de6ffba54a6b2a
which would cause https://github.com/Clon1998/mobileraker_companion/issues/33 to resurface on ARMv7 targets. 
