### PR TITLE
Added Portuguese language

### DIFF
--- a/mobileraker/util/i18n.py
+++ b/mobileraker/util/i18n.py
@@ -36,7 +36,7 @@ _mobileraker_de: Dict[str, str] = {
     'm117_custom_title': 'Nutzer-Benachrichtigung'
 }
 
-_mobileraker_pt: Dict[str, str] = {
+_mobileraker_ptbr: Dict[str, str] = {
     'print_progress_title': 'Progresso de Impressão de $printer_name',
     'print_progress_body': '$progresso, ETA: $a_eta',
     'state_title': 'Status de $printer_name Alterado',

--- a/mobileraker/util/i18n.py
+++ b/mobileraker/util/i18n.py
@@ -36,6 +36,17 @@ _mobileraker_de: Dict[str, str] = {
     'm117_custom_title': 'Nutzer-Benachrichtigung'
 }
 
+_mobileraker_pt: Dict[str, str] = {
+    'print_progress_title': 'Progresso de Impressão de $printer_name',
+    'print_progress_body': '$progresso, ETA: $a_eta',
+    'state_title': 'Status de $printer_name Alterado',
+    'state_printing_body': 'Iniciou a impressão do arquivo: "$file"',
+    'state_paused_body': 'Pausou durante a impressão do arquivo: "$file"',
+    'state_completed_body': 'Concluiu a impressão do arquivo: "$file"',
+    'state_error_body': 'Erro durante a impressão do arquivo: "$file"',
+    'state_standby_body': 'A impressora está em modo de espera',
+    'm117_custom_title': 'Notificação do Usuário'
+}
 
 _mobileraker_hu: Dict[str, str] = {
 


### PR DESCRIPTION
## Feature Request
Currently, the Mobileraker app lacks Portuguese localization, which can hinder the user experience for Portuguese-speaking users. The absence of a native language interface can be frustrating and may lead to misunderstandings or misuse of the app's features.
